### PR TITLE
Update serilog to 4.1.0

### DIFF
--- a/src/Serilog.Enrichers.Kubernetes/Serilog.Enrichers.Kubernetes.csproj
+++ b/src/Serilog.Enrichers.Kubernetes/Serilog.Enrichers.Kubernetes.csproj
@@ -26,7 +26,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Serilog" Version="2.12.0" />
+        <PackageReference Include="Serilog" Version="4.1.0" />
     </ItemGroup>
     <ItemGroup>
       <None Update="KubernetesLoggerConfigurationExtensions.tt">


### PR DESCRIPTION
Update to the latest Serilog package. This allows the use of this library with packages that reference the newer version of Serilog without causing conflicts.